### PR TITLE
Work Items are CGRs and Specifications as defined in the CBGP. Proposals are CGRs but not Specifications. Fixes #11.

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -243,8 +243,7 @@ a Proposal. They may do this for any reason, such as but not limited to:
 
 <ul>
 <li>because the Proposal has become sufficiently complex that writing an
-<a href=https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md>explainer</a>
-is warranted
+explainer is warranted
 <li>because the Proposal is sufficiently complex that having a dedicated
 issue tracker for it is warranted
 <li>because multiple <a href=#implementer>implementers</a> have

--- a/charter.html
+++ b/charter.html
@@ -266,16 +266,14 @@ the repository to a different organization or user, or by archiving it.
 
 <h2 id=work-items>Work Items</h2>
 
-<p>The Community Group may produce <dfn>Work Items</dfn>, which are
-a special kind of Community Group Report whose purpose is to enable
-interoperability between multiple, independent implementations of the
-features defined in it. Every Work Item has one
+<p>The Community Group may produce <dfn>Work Items</dfn>—Specifications
+as defined in the
+<a href=https://www.w3.org/community/about/agreements/>Community and
+Business Group Process</a>—a special kind of Community Group Report
+whose purpose is to enable interoperability between independent
+implementations of the features it defines. Each Work Item has one
 or more <a href=#editors>Editors</a>, who are appointed by
 the <a href=#chairs>Chairs</a>.
-
-<p class=note>Work Items are Specifications as defined in the
-<a href=https://www.w3.org/community/about/agreements/>Community and
-Business Group Process</a>.
 
 <p>The current set of Work Items of the Community Group are:
 

--- a/charter.html
+++ b/charter.html
@@ -308,10 +308,10 @@ Item's explainer up-to-date with the Work Item as it evolves.
 being formally adopted, they usually start out with an explainer.
 
 <p>When a Work Item's Editors deem the Work Item ready for migration to
-a standards body, they will notify the Chairs. The Editors and Chairs
-will then produce a Final Community Group Report and identify the best
-destination standards body. They will then work with the destination
-standards body to successfully migrate the Work Item.
+a standards body, they will notify the Chairs. The CG may produce a
+Final Community Group Report at this time. The Editors and Chairs will
+identify the best destination standards body, and will then work with
+the destination standards body to successfully migrate the Work Item.
 
 <p>The Chairs may remove Work Items. The Chairs
 must <a href=#notices>notify the group</a> of the removal of Work Items,

--- a/charter.html
+++ b/charter.html
@@ -238,12 +238,20 @@ a Proposal. They may do this for any reason, such as but not limited to:
 
 <ul>
 <li>because the Proposal has become sufficiently complex that writing an
-explainer is warranted
+<a href=https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md>explainer</a>
+is warranted
 <li>because the Proposal is sufficiently complex that having a dedicated
 issue tracker for it is warranted
 <li>because multiple <a href=#implementer>implementers</a> have
 expressed interest in the Proposal
 </ul>
+
+<p>Artifacts produced by successful Proposals may include an explainer
+describing the proposed changes to the web platform. Such an explainer
+may serve as the basis for a Work Item, should the Proposal be adopted
+as one. Proposals cannot result in
+<a href=https://www.w3.org/community/reports/>Community Group
+Reports</a>.
 
 <p>Proposals may be withdrawn by their originators, or may be closed by
 the Chairs (if, for example, the Chairs deem the Proposal to
@@ -252,17 +260,22 @@ sufficient <a href=#implementer>implementer</a> support to be adopted as
 a Work Item). If such a Proposal has a dedicated repository, the Chairs
 should take steps to ensure the data is not lost, perhaps by transferring
 the repository to a different organization or user, or by archiving it.
+ips of Proposals, Work Items, and Community Group Reports. Fixes #11.
 
 <h2 id=work-items>Work Items</h2>
 
-<p>A <dfn>Work Item</dfn> is a Proposal that has been formally adopted
-as something the Community Group will work on.  The purpose of adopting
-a Work Item is to develop a specification&mdash;or modifications to
-other specifications&mdash;that enables interoperability between
-different implementations.
+<p>A <dfn>Work Item</dfn> is something that has been formally adopted
+for the Community Group to work on. The purpose of adopting a Work Item
+is to develop a specification&mdash;or modifications to other
+specifications&mdash;that enables interoperability between different
+implementations. Every Work Item has one or
+more <a href=#editors>Editors</a>, who are appointed by
+the <a href=#chairs>Chairs</a>.
 
-<p>Every Work Item has one or more <a href=#editors>Editors</a>, who are
-appointed by the <a href=#chairs>Chairs</a>.
+<p class=note>Work Items typically begin life as a Proposal before being
+formally adopted, and are expected to result in a
+<a href=https://www.w3.org/community/reports/>Community Group Report</a>
+that can be migrated to an appropriate body for standardization.
 
 <p>The current set of Work Items of the Community Group are:
 
@@ -289,13 +302,15 @@ to reflect the current set of Work Items of the Community Group.
 <p>The Chairs may add Work Items, but must not add Work Items which lack
 the support of at least two <a href=#implementer>implementers</a>.
 
-<p class=note>Typically, Work Items begin life as a Proposal before
-being adopted.
+<p>Artifacts of Work Items may include an explainer describing the
+proposed changes to the web platform as well as a Draft Community Group
+Report defining the proposed changes in detail.
 
 <p>When a Work Item's Editors deem the Work Item ready for migration to
 a standards body, they will notify the Chairs. The Editors and Chairs
-will then work together to identify the best destination, and will work
-with the destination standards body to successfully migrate the work.
+will then work together to produce a Final Community Group Report, to
+identify the best destination body, and will work with the destination
+standards body to successfully migrate the work.
 
 <p>The Chairs may remove Work Items. The Chairs
 must <a href=#notices>notify the group</a> of the removal of Work Items,
@@ -444,12 +459,13 @@ for reporting security or privacy issues are
 <a href=https://github.com/privacycg/.github/blob/master/SECURITY.md>posted
 on GitHub</a> and kept up-to-date.
 
-<p>Any change that represents a feature addition must have the support
-of at least two <a href=#implementer>implementers</a>.
+<p>Any change to a <a href=#work-items>Work Item</a> that represents a
+feature addition must have the support of at least
+two <a href=#implementer>implementers</a>.
 
-<p>For any change that removes a feature, the feature being removed must
-either be not widely implemented, or must be in the process of being
-removed from implementations.
+<p>For any change that removes a feature from a Work Item, the feature
+being removed must either be not widely implemented, or must be in the
+process of being removed from implementations.
 
 <h4 id=meetings>Meetings</h4>
 

--- a/charter.html
+++ b/charter.html
@@ -223,11 +223,6 @@ Hazaël-Massieux</a>.
 consideration and potential adoption as a <a href=#work-items>Work
 Item</a>.
 
-<p class=note>While Proposals are Community Group Reports as defined in
-the <a href=https://www.w3.org/community/about/agreements/>Community and
-Business Group Process</a>, they are not Specifications as defined in
-that document.
-
 <p>Any Community Group Participant may make a Proposal by filing
 <a href=https://github.com/privacycg/proposals/issues>an issue</a> in
 the
@@ -255,6 +250,11 @@ expressed interest in the Proposal
 which describe the proposed changes to the web platform, and which may
 serve as the basis for a Work Item (should the Proposal be adopted as
 one).
+
+<p class=note>While explainers are Community Group Reports as defined in
+the <a href=https://www.w3.org/community/about/agreements/>Community and
+Business Group Process</a>, they are not Specifications as defined in
+that document.
 
 <p>Proposals may be withdrawn by their originators, or may be closed by
 the Chairs (if, for example, the Chairs deem the Proposal to

--- a/charter.html
+++ b/charter.html
@@ -263,7 +263,6 @@ sufficient <a href=#implementer>implementer</a> support to be adopted as
 a Work Item). If such a Proposal has a dedicated repository, the Chairs
 should take steps to ensure the data is not lost, perhaps by transferring
 the repository to a different organization or user, or by archiving it.
-ips of Proposals, Work Items, and Community Group Reports. Fixes #11.
 
 <h2 id=work-items>Work Items</h2>
 
@@ -312,9 +311,9 @@ being formally adopted, they usually start out with an explainer.
 
 <p>When a Work Item's Editors deem the Work Item ready for migration to
 a standards body, they will notify the Chairs. The Editors and Chairs
-will then work together to produce a Final Community Group Report,
-identify the best destination body, and work with the destination
-standards body to successfully migrate the work.
+will then produce a Final Community Group Report and identify the best
+destination standards body. They will then work with the destination
+standards body to successfully migrate the Work Item.
 
 <p>The Chairs may remove Work Items. The Chairs
 must <a href=#notices>notify the group</a> of the removal of Work Items,

--- a/charter.html
+++ b/charter.html
@@ -306,11 +306,15 @@ Item's explainer up-to-date with the Work Item as it evolves.
 <p class=note>Since Work Items typically begin life as a Proposal before
 being formally adopted, they usually start out with an explainer.
 
-<p>When a Work Item's Editors deem the Work Item ready for migration to
-a standards body, they will notify the Chairs. The CG may produce a
-Final Community Group Report at this time. The Editors and Chairs will
-identify the best destination standards body, and will then work with
-the destination standards body to successfully migrate the Work Item.
+<p>When a Work Item's Editors deem the Work Item ready for migration,
+they will notify the Chairs. The CG may produce a Final Community Group
+Report at this time. The Editors and Chairs will identify the best
+destination standards body or bodies, and will then work with those
+bodies to successfully migrate the Work Item.
+
+<p class=note>When migrated to the standards track, Work Items might
+become standalone specifications, they might be integrated into one or
+more existing specifications, or even some combination of these options.
 
 <p>The Chairs may remove Work Items. The Chairs
 must <a href=#notices>notify the group</a> of the removal of Work Items,

--- a/charter.html
+++ b/charter.html
@@ -223,6 +223,11 @@ Hazaël-Massieux</a>.
 consideration and potential adoption as a <a href=#work-items>Work
 Item</a>.
 
+<p class=note>While Proposals are Community Group Reports as defined in
+the <a href=https://www.w3.org/community/about/agreements/>Community and
+Business Group Process</a>, they are not Specifications as defined in
+that document.
+
 <p>Any Community Group Participant may make a Proposal by filing
 <a href=https://github.com/privacycg/proposals/issues>an issue</a> in
 the
@@ -246,12 +251,11 @@ issue tracker for it is warranted
 expressed interest in the Proposal
 </ul>
 
-<p>Artifacts produced by successful Proposals may include an explainer
-describing the proposed changes to the web platform. Such an explainer
+<p>Proposals result in
+<a href=https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md>explainers</a>
+which describe the proposed changes to the web platform, and which
 may serve as the basis for a Work Item, should the Proposal be adopted
-as one. Proposals cannot result in
-<a href=https://www.w3.org/community/reports/>Community Group
-Reports</a>.
+as one.
 
 <p>Proposals may be withdrawn by their originators, or may be closed by
 the Chairs (if, for example, the Chairs deem the Proposal to
@@ -264,18 +268,16 @@ ips of Proposals, Work Items, and Community Group Reports. Fixes #11.
 
 <h2 id=work-items>Work Items</h2>
 
-<p>A <dfn>Work Item</dfn> is something that has been formally adopted
-for the Community Group to work on. The purpose of adopting a Work Item
-is to develop a specification&mdash;or modifications to other
-specifications&mdash;that enables interoperability between different
-implementations. Every Work Item has one or
+<p>The Community Group may produce <dfn>Work Items</dfn>, which are
+a special kind of Community Group Report whose purpose is to enable
+interoperability between multiple, independent implementations of the
+features defined in it. Every Work Item has one or
 more <a href=#editors>Editors</a>, who are appointed by
 the <a href=#chairs>Chairs</a>.
 
-<p class=note>Work Items typically begin life as a Proposal before being
-formally adopted, and are expected to result in a
-<a href=https://www.w3.org/community/reports/>Community Group Report</a>
-that can be migrated to an appropriate body for standardization.
+<p class=note>Work Items are Specifications as defined in the
+<a href=https://www.w3.org/community/about/agreements/>Community and
+Business Group Process</a>.
 
 <p>The current set of Work Items of the Community Group are:
 
@@ -302,9 +304,12 @@ to reflect the current set of Work Items of the Community Group.
 <p>The Chairs may add Work Items, but must not add Work Items which lack
 the support of at least two <a href=#implementer>implementers</a>.
 
-<p>Artifacts of Work Items may include an explainer describing the
-proposed changes to the web platform as well as a Draft Community Group
-Report defining the proposed changes in detail.
+<p>Each Work Item should be accompanied by an explainer describing its
+proposed changes to the web platform. Editors should keep the Work
+Item's explainer up-to-date with the Work Item as it evolves.
+
+<p class=note>Since Work Items typically begin life as a Proposal before
+being formally adopted, they usually start out with an explainer.
 
 <p>When a Work Item's Editors deem the Work Item ready for migration to
 a standards body, they will notify the Chairs. The Editors and Chairs

--- a/charter.html
+++ b/charter.html
@@ -314,7 +314,8 @@ bodies to successfully migrate the Work Item.
 
 <p class=note>When migrated to the standards track, Work Items might
 become standalone specifications, they might be integrated into one or
-more existing specifications, or even some combination of these options.
+more existing specifications, or they might result in a combination of
+these options.
 
 <p>The Chairs may remove Work Items. The Chairs
 must <a href=#notices>notify the group</a> of the removal of Work Items,

--- a/charter.html
+++ b/charter.html
@@ -245,7 +245,7 @@ issue tracker for it is warranted
 expressed interest in the Proposal
 </ul>
 
-<p>Proposals result in
+<p>Proposals begin as or evolve into
 <a href=https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md>explainers</a>
 which describe the proposed changes to the web platform, and which may
 serve as the basis for a Work Item (should the Proposal be adopted as

--- a/charter.html
+++ b/charter.html
@@ -252,9 +252,9 @@ expressed interest in the Proposal
 
 <p>Proposals result in
 <a href=https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md>explainers</a>
-which describe the proposed changes to the web platform, and which
-may serve as the basis for a Work Item, should the Proposal be adopted
-as one.
+which describe the proposed changes to the web platform, and which may
+serve as the basis for a Work Item (should the Proposal be adopted as
+one).
 
 <p>Proposals may be withdrawn by their originators, or may be closed by
 the Chairs (if, for example, the Chairs deem the Proposal to
@@ -269,8 +269,8 @@ the repository to a different organization or user, or by archiving it.
 <p>The Community Group may produce <dfn>Work Items</dfn>, which are
 a special kind of Community Group Report whose purpose is to enable
 interoperability between multiple, independent implementations of the
-features defined in it. Every Work Item has one or
-more <a href=#editors>Editors</a>, who are appointed by
+features defined in it. Every Work Item has one
+or more <a href=#editors>Editors</a>, who are appointed by
 the <a href=#chairs>Chairs</a>.
 
 <p class=note>Work Items are Specifications as defined in the

--- a/charter.html
+++ b/charter.html
@@ -246,10 +246,9 @@ expressed interest in the Proposal
 </ul>
 
 <p>Proposals begin as or evolve into
-<a href=https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md>explainers</a>
-which describe the proposed changes to the web platform, and which may
-serve as the basis for a Work Item (should the Proposal be adopted as
-one).
+<a href=https://w3ctag.github.io/explainers>explainers</a> which
+describe the proposed changes to the web platform, and which may serve
+as the basis for a Work Item (should the Proposal be adopted as one).
 
 <p class=note>While explainers are Community Group Reports as defined in
 the <a href=https://www.w3.org/community/about/agreements/>Community and

--- a/charter.html
+++ b/charter.html
@@ -308,8 +308,8 @@ Report defining the proposed changes in detail.
 
 <p>When a Work Item's Editors deem the Work Item ready for migration to
 a standards body, they will notify the Chairs. The Editors and Chairs
-will then work together to produce a Final Community Group Report, to
-identify the best destination body, and will work with the destination
+will then work together to produce a Final Community Group Report,
+identify the best destination body, and work with the destination
 standards body to successfully migrate the work.
 
 <p>The Chairs may remove Work Items. The Chairs


### PR DESCRIPTION
My attempt to address #11.

* Further clarify the relationships of Proposals, Work Items, and Community Group Reports.
* Fix a typo
* Clarify that the feature addition and removal rules apply to Work Items, not Proposals.