### PR TITLE
Make it clearer why the 2 implementer rule exists

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -252,9 +252,13 @@ the repository to a different organization or user, or by archiving it.
 <h2 id=work-items>Work Items</h2>
 
 <p>A <dfn>Work Item</dfn> is a Proposal that has been formally adopted
-as something the Community Group will work on. Every Work Item has one
-or more <a href=#editors>Editors</a>, who are appointed by
-the <a href=#chairs>Chairs</a>.
+as something the Community Group will work on.  The purpose of adopting
+a Work Item is to develop a specification&mdash;or modifications to
+other specifications&mdash;that enables interoperability between
+different implementations.
+
+<p>Every Work Item has one or more <a href=#editors>Editors</a>, who are
+appointed by the <a href=#chairs>Chairs</a>.
 
 <p>The current set of Work Items of the Community Group are:
 


### PR DESCRIPTION
This isn't well articulated, as the charter currently just defines a
rule without context.  Providing that context might help a little.