### PR TITLE
Two small charter tweaks

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -141,7 +141,7 @@ including:
 <li>managing the group's GitHub organization and repositories, website,
   and online presence,
 <li>ensuring the group adheres to its <a href=#process>Process</a>,
-<li>judging proposals as in or <a href=#out-of-scope>out</a>
+<li>judging features or ideas as in or <a href=#out-of-scope>out</a>
 of <a href=#scope>scope</a>,
 <li>focusing the group's limited time on the Proposals and Work Items
 most likely to positively impact privacy on the web via wide

--- a/charter.html
+++ b/charter.html
@@ -150,6 +150,10 @@ implementation and adoption,
 mailing lists, face to face, etc.),
 <li>running teleconferences and
 face-to-face <a href=#meetings>meetings</a>,
+<li>ensuring contributions to Proposals are only made by Community Group
+Participants who have agreed to the
+<a href=https://www.w3.org/community/about/agreements/cla/>W3C Community
+Contributor License Agreement (CLA)</a>,
 <li>and keeping this Charter compliant with the
 <a href=https://www.w3.org/community/about/agreements/>Community and
 Business Group Process</a>, updating it as necessary.


### PR DESCRIPTION
* Clear up an ambiguous use of the word "proposal"
* Make it clear that it's a responsibility of the Chairs to ensure contributions to Proposals are made under the CLA.
