### PR TITLE
Try to address #9.

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -225,7 +225,9 @@ a <a href=#specifications>Specification</a>.
 
 <p>Each Proposal has one or more <dfn>Champions</dfn>, beginning with
 the Community Group Participant who proposed it. Champions are
-self-organized.
+self-organized. Proposals should explicitly list their Champions, and
+Champions should keep this list updated as the set of Champions for the
+Proposal changes.
 
 <p>Any Community Group Participant may make a Proposal by filing
 <a href=https://github.com/privacycg/proposals/issues>an issue</a> in

--- a/charter.html
+++ b/charter.html
@@ -260,9 +260,8 @@ the Chairs (if, for example, the Chairs deem the Proposal to
 be <a href=out-of-scope>out of scope</a>, or if its number of Champions
 drops to zero). If such a Proposal has a dedicated repository, the
 Chairs and Champions should take steps to ensure the data is not lost,
-perhaps by
-transferring the repository to a different organization or user, or by
-archiving it.
+perhaps by archving the repository or by transferring it to a different
+organization or user.
 
 <div id=work-items hidden><!-- keep old links working --></div>
 <h2 id=specifications>Specifications</h2>
@@ -342,8 +341,8 @@ an <a href=#editors>Editor</a> and a replacement cannot be found
 </ul>
 
 <p>The Chairs should take steps to ensure the repositories of removed
-Specifications are not lost, perhaps by transferring the repository to a
-different organization or user, or by archiving it.
+Specifications are not lost, perhaps by archving the repository or by
+transferring it to a different organization or user.
 
 <h2 id=coordination>Coordination</h2>
 

--- a/charter.html
+++ b/charter.html
@@ -260,7 +260,7 @@ the Chairs (if, for example, the Chairs deem the Proposal to
 be <a href=out-of-scope>out of scope</a>, or if its number of Champions
 drops to zero). If such a Proposal has a dedicated repository, the
 Chairs and Champions should take steps to ensure the data is not lost,
-perhaps by archving the repository or by transferring it to a different
+perhaps by archiving the repository or by transferring it to a different
 organization or user.
 
 <div id=work-items hidden><!-- keep old links working --></div>
@@ -316,7 +316,7 @@ evolves.
 
 <p class=note>Because Specifications begin life as Proposals, they
 typically start out with an explainer already written, and Proposal
-Champions are typically appoionted Editors.
+Champions are typically appointed Editors.
 
 <p>When a Specification's Editors deem the Specification ready for
 migration, they will notify the Chairs. The CG may produce a Final
@@ -341,7 +341,7 @@ an <a href=#editors>Editor</a> and a replacement cannot be found
 </ul>
 
 <p>The Chairs should take steps to ensure the repositories of removed
-Specifications are not lost, perhaps by archving the repository or by
+Specifications are not lost, perhaps by archiving the repository or by
 transferring it to a different organization or user.
 
 <h2 id=coordination>Coordination</h2>

--- a/charter.html
+++ b/charter.html
@@ -340,6 +340,9 @@ reasons for removing a Specification are:
 
 <ul>
 <li>because the Specification has been migrated elsewhere
+<li>because it is no longer the <a href=#consensus>consensus</a> of its
+Champions and the Chairs that the Specification is likely to enable and
+lead to independent, interoperable implementations.
 <li>because the Specification no longer has
 an <a href=#editors>Editor</a> and a replacement cannot be found
 </ul>

--- a/charter.html
+++ b/charter.html
@@ -223,6 +223,10 @@ Hazaël-Massieux</a>.
 consideration and potential adoption as
 a <a href=#specifications>Specification</a>.
 
+<p>Each Proposal has one or more <dfn>Champions</dfn>, beginning with
+the Community Group Participant who proposed it. Champions are
+self-organized.
+
 <p>Any Community Group Participant may make a Proposal by filing
 <a href=https://github.com/privacycg/proposals/issues>an issue</a> in
 the
@@ -233,44 +237,41 @@ how they propose to address it.
 <p>The Community Group may discuss the Proposal on GitHub and during
 teleconferences or face-to-face <a href=#meetings>meetings</a>.
 
-<p>The <a href=#chairs>Chairs</a> may create a dedicated repository for
-a Proposal. They may do this for any reason, such as but not limited to:
+<p>Champions are responsible for the technical content of their
+Proposal. They are expected to solicit input from Community Group
+Participants, and they may consider and respond to comments,
+suggestions, and objections on their Proposal from Participants and the
+public.
 
-<ul>
-<li>because the Proposal has become sufficiently complex that writing an
-explainer is warranted
-<li>because the Proposal is sufficiently complex that having a dedicated
-issue tracker for it is warranted
-<li>because multiple <a href=#implementer>implementers</a> have
-expressed interest in the Proposal
-</ul>
+<p>Champions may ask the <a href=#chairs>Chairs</a> to create a
+dedicated repository for their Proposal.
 
 <p>Proposals begin as or evolve into
 <a href=https://w3ctag.github.io/explainers>explainers</a> which
-describe the proposed changes to the web platform, and which may serve
-as the basis for a Specification (should the Proposal be adopted as
-one).
+describe a user-facing problem which needs to be solved and how the
+authors propose to solve it. Explainers are Community Group Reports as
+defined in the
+<a href=https://www.w3.org/community/about/agreements/>Community and
+Business Group Process</a>, but they are not Specifications as defined
+in that document.
 
-<p class=note>While explainers are Community Group Reports as defined in
-the <a href=https://www.w3.org/community/about/agreements/>Community and
-Business Group Process</a>, they are not Specifications as defined in
-that document.
-
-<p>Proposals may be withdrawn by their originators, or may be closed by
+<p>Proposals may be withdrawn by their Champions, or may be closed by
 the Chairs (if, for example, the Chairs deem the Proposal to
-be <a href=out-of-scope>out of scope</a> or the Proposal fails to gain
-sufficient <a href=#implementer>implementer</a> support to be adopted as
-a Specification). If such a Proposal has a dedicated repository, the
-Chairs should take steps to ensure the data is not lost, perhaps by
+be <a href=out-of-scope>out of scope</a>, or if its number of Champions
+drops to zero). If such a Proposal has a dedicated repository, the
+Chairs and Champions should take steps to ensure the data is not lost,
+perhaps by
 transferring the repository to a different organization or user, or by
 archiving it.
 
 <div id=work-items hidden><!-- keep old links working --></div>
 <h2 id=specifications>Specifications</h2>
 
-<p>The Community Group may produce <dfn>Specifications</dfn>—as defined
-in the <a href=https://www.w3.org/community/about/agreements/>Community
-and Business Group Process</a>—a special kind of Community Group Report
+<p>Per the
+<a href=https://www.w3.org/community/about/agreements/>Community and
+Business Group Process</a>, this Community Group may
+produce <dfn>Specifications</dfn>—a special kind of Community
+Group Report
 whose purpose is to enable interoperability between independent
 implementations of the features it defines. Each Specification has one
 or more <a href=#editors>Editors</a>, who are appointed by
@@ -298,17 +299,23 @@ the <a href=#chairs>Chairs</a>.
 <p>This list will be kept <a href=#amendments>updated</a> by the Chairs
 to reflect the current set of Specifications of the Community Group.
 
-<p>The Chairs may add Specifications, but must not add Specifications
-which lack the support of at least
-two <a href=#implementer>implementers</a>.
+<p>The Community Group may adopt a <a href="#proposals">Proposal</a> as
+a Specification when, in the judgement of its Champions and the Chairs,
+such a Specification would be likely to enable and lead to independent,
+interoperable implementations. The Chairs and Champions may solicit
+commitments from organizations to
+provide <a href="https://www.w3.org/2019/Process-20190301/#implementation-experience">adequate
+implementation experience</a> of the Proposal's features, and may take
+such commitments into account when making their decision.
 
 <p>Each Specification should be accompanied by an explainer describing
 its proposed changes to the web platform. Editors should keep the
 Specification's explainer up-to-date with the Specification as it
 evolves.
 
-<p class=note>Since Specifications typically begin life as a Proposal
-before being formally adopted, they usually start out with an explainer.
+<p class=note>Because Specifications begin life as Proposals, they
+typically start out with an explainer already written, and Proposal
+Champions are typically appoionted Editors.
 
 <p>When a Specification's Editors deem the Specification ready for
 migration, they will notify the Chairs. The CG may produce a Final
@@ -328,9 +335,6 @@ reasons for removing a Specification are:
 
 <ul>
 <li>because the Specification has been migrated elsewhere
-<li>because the Specification no longer has the support of
-multiple <a href=#implementer>implementers</a> and is unlikely to regain
-it
 <li>because the Specification no longer has
 an <a href=#editors>Editor</a> and a replacement cannot be found
 </ul>
@@ -371,11 +375,7 @@ Specifications to the standards track.
 
 <dt><a href=https://www.w3.org/community/wicg/>Web Platform Incubator
 Community Group (WICG)</a>
-<dd>WICG is expected to be a major source of Specifications for this
-group.
-<p class=note>Only privacy-related WICG proposals which have the support
-of at least two <a href=#implementer>implementers</a> are eligible for
-this group to take up as Specifications.
+<dd>WICG is expected to be a major source of Proposals for this group.
 </dl>
 
 <h3 id=external-coordination>External Organizations</h3>
@@ -383,7 +383,7 @@ this group to take up as Specifications.
 <dl>
 <dt><a href=https://whatwg.org/>Web Hypertext Application Technology
 Working Group (WHATWG)</a>
-<dd>Much of this group’s work will likely result in pull requests on
+<dd>Many of our Specificaitons will likely result in pull requests on
 various WHATWG specs.
 </dl>
 
@@ -468,14 +468,6 @@ for reporting security or privacy issues are
 <a href=https://github.com/privacycg/.github/blob/master/SECURITY.md>posted
 on GitHub</a> and kept up-to-date.
 
-<p>Any change to a <a href=#specifications>Specification</a> that
-represents a feature addition must have the support of at least
-two <a href=#implementer>implementers</a>.
-
-<p>For any change that removes a feature from a Specification, the
-feature being removed must either be not widely implemented, or must be
-in the process of being removed from implementations.
-
 <h4 id=meetings>Meetings</h4>
 
 <p>The Community Group may hold teleconferences and face-to-face
@@ -509,19 +501,14 @@ facilitate discussion to try to resolve the objection.
 <p>In case of a conflict among Community Group Participants, Editors are
 expected to go to significant lengths to resolve disagreements. In the
 end, they make a judgment call to pick the best option they believe will
-have <a href=#implementer>multi-implementer support</a>.
+preserve privacy and lead to independent, interoperable implementations.
 
 <p>If a Community Group Participant is not satisfied with the resolution
 of an issue, they may request that the Editors revisit the issue. If not
 satisfied with the Editors’ final response, Community Group Participants
-may <a href=#appeals>appeal to the Chairs</a>.
-
-<p>If a Community Group Participant believes the Editors’ choice will
-not have <a href=#implementer>multi-implementer support</a>, and they
-cannot convince the Editors, then they may <a href=#appeals>appeal to
-the Chairs</a>. The Chairs may correct or uphold the decision based on
-their own understanding of support
-from <a href=#implementer>implementers</a>.
+may <a href=#appeals>appeal to the Chairs</a>. The Chairs may correct or
+uphold the decision based on their own understanding of what will best
+preserve privacy and lead to independent, interoperable implementations.
 
 <p>It is the Chairs’ responsibility to ensure that the decision process
 is fair and does not unreasonably favor or discriminate against any
@@ -542,7 +529,7 @@ content and specify the most privacy-preserving, web-compatible
 approach. If there isn’t enough existing web content affected by the
 change to make compatibility a concern, the Editors will, to the extent
 possible, be consistent with our goal to increase user privacy and align
-with <a href=#implementer>implementer</a> majority.
+with implementer majority.
 
 <p>Specifications should not make references to or rely on specific
 browser engine implementation details.
@@ -637,54 +624,6 @@ group</a> of any material changes to the Charter.
     then Consensus may be established simply by moving forward on the
     proposal or a course of action; this is anticipated to be the norm
     for most matters.”
-  <dt id=implementer>implementer
-  <dd>
-    <p>The WHATWG
-    <a href=https://whatwg.org/sg-agreement#qualifying-entity>defines
-    implementer</a> as "an entity that develops one of the core
-    end-to-end integrated web browser platform engines and distributes
-    its integrated implementations widely." This definition is useful
-    for determining multi-implementer support of core web platform
-    features, features which are typically and reasonably implemented
-    within the core end-to-end integrated web browser platform engines,
-    and this Community Group relies on this definition for such
-    features.
-    <p>Some privacy-related features ship in browsers but are not
-    implemented within browser engines. In cases where multiple entities
-    share a browser engine in common, they only count as multiple
-    implementers of a feature if that feature’s implementations are
-    separate and are not believed to be specific to the internals of the
-    engine.
-    <p class=example title="Example: two browsers, separate engines">The
-    Peach Foundation ships Walkabout, a web browser built on the
-    MeshTools browser engine. Nanoware also ships a web browser, Vertex,
-    built on the Shrug browser engine. If a feature has the support in
-    both MeshTools and Shrug, as shipping (or as is expected to ship) in
-    Walkabout and Vertex, it can be said to have multi-implementer
-    support.
-    <p class=example title="Example: two browsers, shared engine, shared
-    implementation">Valiant Inc. ships Valiant, a web browser built on
-    the Shrug browser engine. The Avogadro Corporation ships a web
-    browser, Veneer, also built on the Shrug browser engine. A feature
-    implemented in Shrug counts as having one implementer supporting it,
-    even if that feature ships in both Valiant and Veneer.
-    <p class=example title="Example: two browsers, shared engine,
-    separate implementations (existing)">Valiant and Vertex both ship a
-    feature, but it is not a feature with a shared, underlying
-    implementation in the Shrug engine. Such a feature counts as having
-    two implementers supporting it, even though Valiant and Vertex are
-    both built on Shrug, because this particular feature has seperate,
-    non-shared implementations.
-    <p class=example title="Example: two browsers, shared engine,
-    separate implementations (expected)">Valiant and Vertex (who, again,
-    share an engine) both express implementer interest in a feature that
-    does not yet have any implementations. If both implementers indicate
-    that they do not expect to share an implementation (they do not
-    expect to land their implementations in Shrug), the feature counts
-    as having two implementers supporting it. If both implementers
-    expect they’d share an implementation in Shrug, it counts as having
-    one implementer supporting it.
-  </dd>
 </dl>
 
 <h2 id=about>About this Charter</h2>

--- a/charter.html
+++ b/charter.html
@@ -300,11 +300,11 @@ to reflect the current set of Specifications of the Community Group.
 
 <p>The Community Group may adopt a <a href="#proposals">Proposal</a> as
 a Specification if it is the <a href=#consensus>consensus</a> of its
-Champions and the Chairs that such
-a Specification would be likely to enable and lead to independent,
-interoperable implementations. The Chairs and Champions may solicit
-commitments from organizations to
-provide <a href="https://www.w3.org/2019/Process-20190301/#implementation-experience">adequate
+Champions and the Chairs that such a Specification would be likely to
+enable and lead to independent, interoperable implementations. The
+Chairs and Champions may solicit commitments from organizations to
+provide
+<a href="https://www.w3.org/2019/Process-20190301/#implementation-experience">adequate
 implementation experience</a> of the Proposal's features, and may take
 such commitments or other such expressions of implementer interest into
 account when making their decision.

--- a/charter.html
+++ b/charter.html
@@ -306,7 +306,8 @@ interoperable implementations. The Chairs and Champions may solicit
 commitments from organizations to
 provide <a href="https://www.w3.org/2019/Process-20190301/#implementation-experience">adequate
 implementation experience</a> of the Proposal's features, and may take
-such commitments into account when making their decision.
+such commitments or other such expressions of implementer interest into
+account when making their decision.
 
 <p>Each Specification should be accompanied by an explainer describing
 its proposed changes to the web platform. Editors should keep the

--- a/charter.html
+++ b/charter.html
@@ -384,7 +384,7 @@ Community Group (WICG)</a>
 <dl>
 <dt><a href=https://whatwg.org/>Web Hypertext Application Technology
 Working Group (WHATWG)</a>
-<dd>Many of our Specificaitons will likely result in pull requests on
+<dd>Many of our Specifications will likely result in pull requests on
 various WHATWG specs.
 </dl>
 

--- a/charter.html
+++ b/charter.html
@@ -244,7 +244,9 @@ suggestions, and objections on their Proposal from Participants and the
 public.
 
 <p>Champions may ask the <a href=#chairs>Chairs</a> to create a
-dedicated repository for their Proposal.
+dedicated repository for their Proposal. The Chairs will generally honor
+such requests, though they may choose not to (if, for example, they
+believe the Proposal to be <a href=#out-of-scope>out of scope</a>).
 
 <p>Proposals begin as or evolve into
 <a href=https://w3ctag.github.io/explainers>explainers</a> which

--- a/charter.html
+++ b/charter.html
@@ -300,8 +300,9 @@ the <a href=#chairs>Chairs</a>.
 to reflect the current set of Specifications of the Community Group.
 
 <p>The Community Group may adopt a <a href="#proposals">Proposal</a> as
-a Specification when, in the judgement of its Champions and the Chairs,
-such a Specification would be likely to enable and lead to independent,
+a Specification if it is the <a href=#consensus>consensus</a> of its
+Champions and the Chairs that such
+a Specification would be likely to enable and lead to independent,
 interoperable implementations. The Chairs and Champions may solicit
 commitments from organizations to
 provide <a href="https://www.w3.org/2019/Process-20190301/#implementation-experience">adequate


### PR DESCRIPTION
This is a strawman fix for #9 to facilitate discussion. It builds on #23, and contains the following changes:

* Defines the role of a proposal champion (like in TC39). Champions are to Proposals as Editors are to Specifications.
* Removes the clause about removing proposals because they lack multi-implementer support.
* Changes how proposals get adopted as specifications. Some new wording, and some ideas from jyasskin/privacycg.github.io
* Removes the clauses about specification feature additions and removals.
* Removes the clause about objecting to an editors' decision solely because it lacks multiple-implementer support
* Removes the definition of implementer.