### PR TITLE
Add requestStorageAccessFor[Origin]

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -325,6 +325,13 @@ the <a href=#chairs>Chairs</a>.
       <td><a href=https://fetch.spec.whatwg.org/>Fetch</a> &amp;
         <a href=https://html.spec.whatwg.org/>HTML</a> standards
     </tr>
+    <tr id=storage-access4>
+      <th><a href=https://privacycg.github.io/storage-access-for/>Advance Requests for Storage Access</a>
+      <td><a href=https://github.com/mreichhoff>Matt Reichhoff</a> &amp;
+        <a href=https://github.com/johannhof>Johann Hofmann</a>
+      <td><a href=https://html.spec.whatwg.org/>HTML</a> &amp;
+        <a href=https://storage.spec.whatwg.org/>Storage</a> standards
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
... with a name that can be changed, though I think we need to be clear about what distinguishes this from Storage Access proper.

Note that we are keeping this distinct from Storage Access as that is effectively graduated already, we're just holding on to it so that can complete the transition to WHATWG without falling through a process hole.

@mreichhoff, @johannhof, please review names.