### PR TITLE
Login status is apparently now in FedID WG

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -300,11 +300,6 @@ the <a href=#chairs>Chairs</a>.
           <a href=https://github.com/krgovind>Kaustubha Govind</a>
       <td>IETF
     </tr>
-    <tr id=is-logged-in>
-      <th><a href=https://github.com/privacycg/is-logged-in>The Login Status API</a>
-      <td><a href=https://github.com/johnwilander>John Wilander</a>
-      <td><a href=https://www.w3.org/2011/webappsec/>WebAppSec</a>
-    </tr>
     <tr id=pcm>
       <th><a href=https://github.com/privacycg/private-click-measurement>Private Click Measurement</a>
       <td><a href=https://github.com/johnwilander>John Wilander</a>


### PR DESCRIPTION
See https://github.com/w3c-fedid/login-status

This is a *proposal*.  We also need to discuss what to do with the repository.  Should we archive it?

@johnwilander ?