### PR TITLE
Replace 2 Google nav-tracking editors with Ari Chivukula and Andrew Liu

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -306,9 +306,9 @@ the <a href=#chairs>Chairs</a>.
     </tr>
     <tr id=nav-tracking>
       <th><a href=https://privacycg.github.io/nav-tracking-mitigations/>Navigational-Tracking Mitigations</a>
-      <td><a href=https://github.com/wanderview>Ben Kelly</a>,
-        <a href=https://github.com/pes10k>Pete Snyder</a>,
-        <a href=https://github.com/jyasskin>Jeffrey Yasskin</a>
+      <td><a href=https://github.com/arichiv>Ari Chivukula</a>,
+        <a href=https://github.com/mrpickles>Andrew Liu</a>,
+        <a href=https://github.com/pes10k>Pete Snyder</a>
       <td><a href=https://fetch.spec.whatwg.org/>Fetch</a> &amp;
         <a href=https://html.spec.whatwg.org/>HTML</a> standards
     </tr>


### PR DESCRIPTION
This copies https://github.com/privacycg/nav-tracking-mitigations/pull/97 into the charter. Could the chairs also make sure the new editors have the appropriate access to the https://github.com/privacycg/nav-tracking-mitigations/ repo?